### PR TITLE
Fix a typo.

### DIFF
--- a/mlflow_extend/logging.py
+++ b/mlflow_extend/logging.py
@@ -76,7 +76,7 @@ def log_metrics_flatten(
     metrics: dict, step: Optional[int] = None, parent_key: str = "", sep: str = ".",
 ) -> None:
     """
-    Log a batch of params after flattening.
+    Log a batch of metrics after flattening.
 
     Parameters
     ----------


### PR DESCRIPTION
A nit but `params` seems to be a typo for `metrics`.